### PR TITLE
Solved Clone : Remove Software Clone in showErrorDialog Method 

### DIFF
--- a/app/src/main/java/de/tadris/fitness/util/DialogUtils.java
+++ b/app/src/main/java/de/tadris/fitness/util/DialogUtils.java
@@ -23,6 +23,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import androidx.appcompat.app.AlertDialog;
 import androidx.annotation.StringRes;
+
 import de.tadris.fitness.R;
 
 public class DialogUtils {


### PR DESCRIPTION
The same showErrorDialog() method was defined in multiple locations, leading to code duplication. This violates DRY (Don't Repeat Yourself) principles and increases maintenance complexity. 

To eliminate redundancy, the showErrorDialog() method was moved into the existing DialogUtils.java utility class. Now, instead of each class defining its own method, they reuse the centralized method from DialogUtils. 