### PR TITLE
Moved the hardcoded API_KEY to resolve security issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 # gradle
 local.properties
 
+app/src/main/res/config.properties

--- a/app/src/main/java/de/tadris/fitness/map/tilesource/ThunderforestTileSource.java
+++ b/app/src/main/java/de/tadris/fitness/map/tilesource/ThunderforestTileSource.java
@@ -21,11 +21,27 @@ package de.tadris.fitness.map.tilesource;
 
 import org.mapsforge.core.model.Tile;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.util.Properties;
 
 public class ThunderforestTileSource extends FitoTrackTileSource {
 
-    private static final String API_KEY = "87b07337e42c405db6d8d39b1c0c179e";
+    private static final String API_KEY = loadApiKey();
+
+    private static String loadApiKey() {
+        Properties properties = new Properties();
+        try (InputStream input = ThunderforestTileSource.class.getClassLoader().getResourceAsStream("config.properties")) {
+            if (input == null) {
+                throw new IllegalStateException("Missing config.properties file. Please add it as per README instructions.");
+            }
+            properties.load(input);
+            return properties.getProperty("THUNDERFOREST_API_KEY");
+        } catch (IOException e) {
+            throw new RuntimeException("Error loading API key from config file", e);
+        }
+    }
 
     public static final ThunderforestTileSource OUTDOORS = new ThunderforestTileSource("outdoors", "Outdoor");
     public static final ThunderforestTileSource CYCLE_MAP = new ThunderforestTileSource("cycle", "Cycle Map");

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ buildscript {
     }
 }
 
+plugins {
+    id("org.sonarqube") version "6.0.1.5171"
+}
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
Move the API key to an external config.properties file stored in app/src/main/resources/ and update ThunderforestTileSource.java to read the API key dynamically.