### PR TITLE
remove stackTrace()

### DIFF
--- a/app/src/main/java/de/tadris/fitness/osm/OAuthAuthentication.java
+++ b/app/src/main/java/de/tadris/fitness/osm/OAuthAuthentication.java
@@ -84,7 +84,6 @@ public class OAuthAuthentication {
                     dialogController.cancel();
                 });
             } catch (OAuthException e) {
-                e.printStackTrace();
                 handler.post(() -> {
                     dialogController.cancel();
                     listener.authenticationFailed();


### PR DESCRIPTION
Discovered a printStackTrace() statement in the production code that might leak sensitive information about how the application work or sensitive data that is useful for development purposes, but should not be accessible to users in a production setting