### PR TITLE
Replace printStackTrace() with secure logging in SettingsActivity.java

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
@@ -52,7 +52,7 @@ public class SettingsActivity extends FitoTrackSettingsActivity {
     private final Handler mHandler = new Handler();
 
         private void handleBackupError(Exception e, ProgressDialogController dialogController, int errorMessage) {
-        e.printStackTrace();
+        Log.e("BackupError", "An error occurred during backup", e);
         mHandler.post(() -> {
             dialogController.cancel();
             showErrorDialog(e, R.string.error, errorMessage);


### PR DESCRIPTION
Refactored handleBackupError in SettingsActivity to use Log.e() instead of printStackTrace() for secure and production-ready error handling
